### PR TITLE
FFT for Windowed Data

### DIFF
--- a/sonus/examples.py
+++ b/sonus/examples.py
@@ -1,0 +1,20 @@
+"""
+Demonstrates functions, and helps visualize intermediates.
+"""
+
+import matplotlib.pyplot as plt
+
+
+def plot_fft(data, idx):
+    """
+    Show the frequency plot of a row.
+    :param data: pd.DataFrame processed by sonus.pipeline.fft
+    :param idx: Index to plot
+    :return: None, plot displayed.
+    """
+
+    fig, ax = plt.subplots()
+    plt.plot(data.loc[idx, ('fft_x')], data.loc[idx, ('fft_y')])
+    plt.ylabel('Amplitude')
+    plt.xlabel('Frequency [Hz]')
+    fig.show()

--- a/sonus/examples.py
+++ b/sonus/examples.py
@@ -5,10 +5,29 @@ Demonstrates functions, and helps visualize intermediates.
 import matplotlib.pyplot as plt
 
 
-def plot_fft(data, idx):
+def plot_fft(data, fft_x, idx, fft_start=8000, fft_end=11990):
     """
     Show the frequency plot of a row.
-    :param data: pd.DataFrame processed by sonus.pipeline.fft
+    :param fft_x: np.ndarray X-Axis of FFT
+    :param fft_end: End column index of fft
+    :param fft_start: Start column index of fft
+    :param data: np.ndarray processed by sonus.pipeline.fft
+    :param idx: Index to plot
+    :return: None, plot displayed.
+    """
+
+    fig, ax = plt.subplots()
+    plt.plot(fft_x, data[idx, fft_start:fft_end])
+    plt.ylabel('Amplitude')
+    plt.xlabel('Frequency [Hz]')
+    plt.title(f'Sample {idx} FFT')
+    fig.show()
+
+
+def plot_fft_df(data, idx):
+    """
+    Show the frequency plot of a row.
+    :param data: pd.DataFrame processed by sonus.pipeline.fft_df
     :param idx: Index to plot
     :return: None, plot displayed.
     """

--- a/sonus/pipeline.py
+++ b/sonus/pipeline.py
@@ -2,5 +2,46 @@
 Code to process data in a Pipeline.
 """
 
+import sys
+import pandas as pd
 import numpy as np
 import sklearn
+import scipy
+
+
+def fft(data: pd.DataFrame):
+    """
+    Adds a frequency space feature to the data. The audio column should be in wav format, np.ndarrays.
+    https://makersportal.com/blog/2018/9/13/audio-processing-in-python-part-i-sampling-and-the-fast-fourier-transform
+    https://www.youtube.com/watch?v=17cOaqrwXlo
+    https://www.youtube.com/watch?v=aQKX3mrDFoY  << Especially helpful
+    https://github.com/markjay4k/Audio-Spectrum-Analyzer-in-Python
+    :param data: pd.DataFrame input DataFrame with ['audio'] column to transform
+    :return: pd.DataFrame with new columns ['fft_x'], ['fft_y']
+    """
+
+    assert 'audio' in data.keys(), "'audio' must be present in keys."
+    assert len(data) > 0, "data does not contain any rows."
+    assert type(data.iloc[0]['audio']) is np.ndarray, "'audio' must contain numpy arrays."
+
+    fft_xs = []
+    fft_ys = []
+
+    for i, row in data.iterrows():
+        sys.stdout.write(f"\r[-] FFT: {i} of {len(data)} ({i / len(data) * 100: .2f}%)")
+        sys.stdout.flush()
+        n_samples = len(row['audio'])
+        fft_y = scipy.fft(row['audio'])
+        fft_x = scipy.fft.fftfreq(len(fft_y), (1.0 / row['samplerate']))
+        fft_y = np.abs(fft_y[0:(n_samples // 2)])  # Take real components of first half
+        # fft_y = np.multiply(fft_y, 2) / (32767 * (n_samples // 2))  # Rescale, 16-bit PCM
+        fft_y = np.divide(np.multiply(fft_y, 2), n_samples)
+        fft_x = fft_x[0:(n_samples // 2)]  # Take the first half of the x-axis too
+        fft_xs.append(fft_x)
+        fft_ys.append(fft_y)
+    sys.stdout.write(f"\r[-] FFT: Completed {len(data)} ({i / len(data) * 100: .2f}%)")
+    sys.stdout.flush()
+    data['fft_y'] = pd.Series(fft_ys)
+    data['fft_x'] = pd.Series(fft_xs)
+
+    return data

--- a/sonus/pipeline.py
+++ b/sonus/pipeline.py
@@ -9,7 +9,54 @@ import sklearn
 import scipy
 
 
-def fft(data: pd.DataFrame):
+def fft(data: np.ndarray, low_pass=20, high_pass=20000, return_x=False):
+    """
+    Adds a frequency space feature to the data. The data should be a windowed audio array.
+    The output of this algorithm is appended columns at the end.
+    https://makersportal.com/blog/2018/9/13/audio-processing-in-python-part-i-sampling-and-the-fast-fourier-transform
+    https://www.youtube.com/watch?v=17cOaqrwXlo
+    https://www.youtube.com/watch?v=aQKX3mrDFoY  << Especially helpful
+    https://github.com/markjay4k/Audio-Spectrum-Analyzer-in-Python
+    :param return_x: Return the FFT x-axis.
+    :param high_pass: Where to stop reporting, at the higher end of the FFT
+    :param low_pass: Where to start reporting the low end of the FFT
+    :param data: np.ndarray Windowed audio data for training
+    :return: np.ndarray with appended columns, extra length of high_pass-low_pass. (or tuple x_axis, np.ndarray)
+    """
+
+    assert high_pass > low_pass, f"Invalid FFT window {low_pass} to {high_pass}"
+
+    n_samples = data.shape[1]
+    fft_ys = []
+
+    fft_x = scipy.fft.fftfreq(n_samples, (1.0 / 16000))  # 16000 is the sample rate
+    fft_x = fft_x[0:(n_samples // 2)]  # Take the first half of the x-axis too
+    pass_mask = [True if low_pass <= x <= high_pass else False for x in fft_x]
+    fft_x = fft_x[pass_mask]
+
+    for i, row in enumerate(data):
+        sys.stdout.write(f"\r[-] FFT: {i} of {len(data)} ({i / len(data) * 100: .2f}%)")
+        sys.stdout.flush()
+        n_samples = len(row)
+        fft_y = scipy.fft(row)
+        fft_y = np.abs(fft_y[0:(n_samples // 2)])  # Take real components of first half
+        # fft_y = np.multiply(fft_y, 2) / (32767 * (n_samples // 2))  # Rescale, 16-bit PCM
+        fft_y = np.divide(np.multiply(fft_y, 2), n_samples)
+        fft_y = fft_y[pass_mask]  # Mask out unwanted values
+        fft_ys.append(fft_y)
+    sys.stdout.write(f"\r[-] FFT: Completed {len(data)} (100%)")
+    sys.stdout.flush()
+
+    fft_ys = np.array(fft_ys)
+    result = np.concatenate((data, fft_ys), axis=1)
+
+    if not return_x:
+        return result
+    else:
+        return fft_x, result
+
+
+def fft_df(data: pd.DataFrame):
     """
     Adds a frequency space feature to the data. The audio column should be in wav format, np.ndarrays.
     https://makersportal.com/blog/2018/9/13/audio-processing-in-python-part-i-sampling-and-the-fast-fourier-transform


### PR DESCRIPTION
I've added `sonus.pipeline.fft` (and left legacy `sonus.pipeline.fft_df`) which should implement FFT for the windowed data. The function `sonus.pipeline.fft` appends columns to the X data, so we'll need to be careful keeping track of which column is which moving forwards. The fft also now has a cutoff so that all the frequency data is in the range of human speech (this is customizable).

Here's some example code and plots:

`import sonus.pipeline`
`import sonus.parse`
`import sonus.examples`
`data = pickle.load(open('data/vox2_test_aac_wav.pkl', 'rb'))`
`data = data.iloc[0:100]`
`X_train, X_test, y_train, y_test = sonus.parse.window_data(data['audio'], data['id'], 0.5, 0.5, 16000, 0.25)`
`fft_x, fftout = sonus.pipeline.fft(X_train, return_x=True)`

`sonus.examples.plot_fft(fftout, fft_x, 50)`

![image](https://user-images.githubusercontent.com/20449792/87885976-7f625300-c9e7-11ea-911f-e24c58f7301a.png)

`sonus.examples.plot_fft(fftout, fft_x, 100)`

![image](https://user-images.githubusercontent.com/20449792/87885984-8c7f4200-c9e7-11ea-87e3-2e48a694a076.png)
